### PR TITLE
Add Buffer::int()

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -17,7 +17,7 @@ tools:
     php_pdepend:
         excluded_dirs: [vendor, build, tests]
     external_code_coverage:
-        timeout: 1800
+        timeout: 600
         runs: 3
 
 changetracking:

--- a/src/Buffertools/Buffer.php
+++ b/src/Buffertools/Buffer.php
@@ -3,7 +3,7 @@
 namespace BitWasp\Buffertools;
 
 use Mdanter\Ecc\EccFactory;
-use Mdanter\Ecc\MathAdapterInterface;
+use Mdanter\Ecc\Math\MathAdapterInterface;
 
 class Buffer
 {
@@ -18,7 +18,7 @@ class Buffer
     private $buffer;
 
     /**
-     * @var \Mdanter\Ecc\MathAdapterInterface
+     * @var MathAdapterInterface
      */
     private $math;
 
@@ -31,7 +31,6 @@ class Buffer
     public function __construct($byteString = '', $byteSize = null, MathAdapterInterface $math = null)
     {
         $this->math = $math ?: EccFactory::getAdapter();
-
         if ($byteSize !== null) {
             // Check the integer doesn't overflow its supposed size
             if ($this->math->cmp(strlen($byteString), $byteSize) > 0) {
@@ -47,14 +46,35 @@ class Buffer
 
     /**
      * Create a new buffer from a hex string
+     *
      * @param $hex
-     * @param integer $bitSize
+     * @param integer $byteSize
+     * @param MathAdapterInterface $math
      * @return Buffer
      * @throws \Exception
      */
-    public static function hex($hex = '', $bitSize = null)
+    public static function hex($hex = '', $byteSize = null, MathAdapterInterface $math = null)
     {
-        return new self(pack("H*", $hex), $bitSize);
+        return new self(pack("H*", $hex), $byteSize, $math);
+    }
+
+    /**
+     * Create a new buffer from an integer
+     *
+     * @param $int
+     * @param null $byteSize
+     * @param MathAdapterInterface $math
+     * @return Buffer
+     */
+    public static function int($int, $byteSize = null, MathAdapterInterface $math = null)
+    {
+        $math = EccFactory::getAdapter();
+        $hex = $math->decHex($int);
+        if (strlen($hex) % 2 == 1) {
+            $hex = '0' . $hex;
+        }
+
+        return self::hex($hex, $byteSize, $math);
     }
 
     /**
@@ -77,7 +97,9 @@ class Buffer
             throw new \Exception('Length exceeds buffer length');
         }
 
-        return new self(substr($this->getBinary(), $start, $end));
+        $string = substr($this->getBinary(), $start, $end);
+        $length = strlen($string);
+        return new self($string, $length, $this->math);
     }
 
     /**

--- a/src/Buffertools/Buffer.php
+++ b/src/Buffertools/Buffer.php
@@ -70,9 +70,6 @@ class Buffer
     {
         $math = EccFactory::getAdapter();
         $hex = $math->decHex($int);
-        if (strlen($hex) % 2 == 1) {
-            $hex = '0' . $hex;
-        }
 
         return self::hex($hex, $byteSize, $math);
     }

--- a/src/Buffertools/Parser.php
+++ b/src/Buffertools/Parser.php
@@ -13,7 +13,7 @@ class Parser
     private $string;
 
     /**
-     * @var \Mdanter\Ecc\MathAdapterInterface
+     * @var \Mdanter\Ecc\Math\MathAdapterInterface
      */
     private $math;
 

--- a/tests/BufferTest.php
+++ b/tests/BufferTest.php
@@ -15,12 +15,7 @@ class BufferTest extends \PHPUnit_Framework_TestCase
     /**
      * @var string
      */
-    protected $bufferType;
-
-    public function __construct()
-    {
-        $this->bufferType = 'BitWasp\Buffertools\Buffer';
-    }
+    protected $bufferType= 'BitWasp\Buffertools\Buffer';
 
     public function setUp()
     {
@@ -107,6 +102,26 @@ class BufferTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(1, Buffer::hex('41')->getSize());
         $this->assertEquals(4, Buffer::hex('41414141')->getSize());
         $this->assertEquals(4, Buffer::hex('41', 4)->getSize());
+    }
+
+    public function IntVectors()
+    {
+        $math = EccFactory::getAdapter();
+
+        return array(
+            array('1',  1,      '01', $math),
+            array('1',  null,   '01', $math),
+            array('20', 1,      '14', $math)
+        );
+    }
+
+    /**
+     * @dataProvider IntVectors
+     */
+    public function testIntConstruct($int, $size, $expectedHex, $math)
+    {
+        $buffer = Buffer::int($int, $size, $math);
+        $this->assertEquals($expectedHex, $buffer->getHex());
     }
 
     public function testSlice()

--- a/tests/Types/ByteStringTest.php
+++ b/tests/Types/ByteStringTest.php
@@ -15,7 +15,6 @@ class ByteStringTest extends BinaryTest
 {
     public function getVectors()
     {
-        echo 'called';
         $math = MathAdapterFactory::getAdapter();
         return [
             [$math, 1, '04'],


### PR DESCRIPTION
New type constructing function - Buffer::int($int) can be called on an arbitrary sized number, optionally adding a bounding bytesize. 

Also fixes slice() - math wasn't being passed to the new Buffer.