### PR TITLE
Fix buffer int

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ script:
 
 after_success:
   - wget https://scrutinizer-ci.com/ocular.phar
-  - sh -c 'if [ "$TRAVIS_PHP_VERSION" != "hhvm" ] && [ "$TRAVIS_PHP_VERSION" != "nightly"  ]; then php ocular.phar code-coverage:upload --format=php-clover build/docs/clover.xml; fi;'
+  - sh -c 'if [ "$TRAVIS_PHP_VERSION" != "hhvm" && "$TRAVIS_PHP_VERSION" !== "nightly" ] && [ "$TRAVIS_PHP_VERSION" != "nightly"  ]; then php ocular.phar code-coverage:upload --format=php-clover build/docs/clover.xml; fi;'
 
 matrix:
     fast_finish: true

--- a/src/Buffertools/Buffer.php
+++ b/src/Buffertools/Buffer.php
@@ -55,6 +55,9 @@ class Buffer
      */
     public static function hex($hex = '', $byteSize = null, MathAdapterInterface $math = null)
     {
+        if ($byteSize > 0 && !ctype_xdigit($hex)) {
+            throw new \InvalidArgumentException('Buffer::hex(): non-hex character passed');
+        }
         return new self(pack("H*", $hex), $byteSize, $math);
     }
 

--- a/src/Buffertools/Buffer.php
+++ b/src/Buffertools/Buffer.php
@@ -68,7 +68,7 @@ class Buffer
      */
     public static function int($int, $byteSize = null, MathAdapterInterface $math = null)
     {
-        $math = EccFactory::getAdapter();
+        $math = $math ?: EccFactory::getAdapter();
         $hex = $math->decHex($int);
 
         return self::hex($hex, $byteSize, $math);

--- a/src/Buffertools/Parser.php
+++ b/src/Buffertools/Parser.php
@@ -4,6 +4,7 @@ namespace BitWasp\Buffertools;
 
 use BitWasp\Buffertools\Exceptions\ParserOutOfRange;
 use Mdanter\Ecc\EccFactory;
+use Mdanter\Ecc\Math\MathAdapterInterface;
 
 class Parser
 {

--- a/src/Buffertools/Types/ByteString.php
+++ b/src/Buffertools/Types/ByteString.php
@@ -99,7 +99,8 @@ class ByteString extends AbstractType
                 '0',
                 STR_PAD_LEFT
             ),
-            $this->length
+            $this->length,
+            $this->getMath()
         );
     }
 }


### PR DESCRIPTION
Should use $math if provided value isn't null. 
Also added optional MathAdapterInterface parameter to Parser, and fixed further instances of $math not being passed to new instances. 