### PR TITLE
Add Buffer types

### DIFF
--- a/src/Buffertools/Buffer.php
+++ b/src/Buffertools/Buffer.php
@@ -55,10 +55,7 @@ class Buffer
      */
     public static function hex($hex = '', $byteSize = null, MathAdapterInterface $math = null)
     {
-        if ($byteSize > 0 && !ctype_xdigit($hex)) {
-            throw new \InvalidArgumentException('Buffer::hex(): non-hex character passed');
-        }
-        return new self(pack("H*", $hex), $byteSize, $math);
+        return new BufferHex($hex, $byteSize, $math);
     }
 
     /**
@@ -71,10 +68,7 @@ class Buffer
      */
     public static function int($int, $byteSize = null, MathAdapterInterface $math = null)
     {
-        $math = $math ?: EccFactory::getAdapter();
-        $hex = $math->decHex($int);
-
-        return self::hex($hex, $byteSize, $math);
+        return new BufferInt($int, $byteSize, $math);
     }
 
     /**

--- a/src/Buffertools/BufferHex.php
+++ b/src/Buffertools/BufferHex.php
@@ -2,7 +2,6 @@
 
 namespace BitWasp\Buffertools;
 
-
 use Mdanter\Ecc\EccFactory;
 use Mdanter\Ecc\Math\MathAdapterInterface;
 

--- a/src/Buffertools/BufferHex.php
+++ b/src/Buffertools/BufferHex.php
@@ -11,8 +11,8 @@ class BufferHex extends Buffer
     public function __construct($hexString = '', $byteSize = null, MathAdapterInterface $math = null)
     {
         $strlen = strlen($hexString);
-        if ($strlen > 0 && $strlen % 2 == 0 && ctype_xdigit($hexString)) {
-            throw new \InvalidArgumentException('BufferHex: non-hex character passed');
+        if ($strlen > 0 && ($strlen % 2 != 0 || !ctype_xdigit($hexString))) {
+            throw new \InvalidArgumentException('BufferHex: non-hex character passed: ' . $hexString);
         }
 
         $math = $math ?: EccFactory::getAdapter();

--- a/src/Buffertools/BufferHex.php
+++ b/src/Buffertools/BufferHex.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace BitWasp\Buffertools;
+
+
+use Mdanter\Ecc\EccFactory;
+use Mdanter\Ecc\Math\MathAdapterInterface;
+
+class BufferHex extends Buffer
+{
+    public function __construct($hexString = '', $byteSize = null, MathAdapterInterface $math = null)
+    {
+        $strlen = strlen($hexString);
+        if ($strlen > 0 && $strlen % 2 == 0 && ctype_xdigit($hexString)) {
+            throw new \InvalidArgumentException('BufferHex: non-hex character passed');
+        }
+
+        $math = $math ?: EccFactory::getAdapter();
+        $binary = pack("H*", $hexString);
+        parent::__construct($binary, $byteSize, $math);
+    }
+}

--- a/src/Buffertools/BufferInt.php
+++ b/src/Buffertools/BufferInt.php
@@ -2,7 +2,6 @@
 
 namespace BitWasp\Buffertools;
 
-
 use Mdanter\Ecc\EccFactory;
 use Mdanter\Ecc\Math\MathAdapterInterface;
 

--- a/src/Buffertools/BufferInt.php
+++ b/src/Buffertools/BufferInt.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace BitWasp\Buffertools;
+
+
+use Mdanter\Ecc\EccFactory;
+use Mdanter\Ecc\Math\MathAdapterInterface;
+
+class BufferInt extends BufferHex
+{
+    /**
+     * @param string $integer
+     * @param integer|null $byteSize
+     * @param MathAdapterInterface|null $math
+     */
+    public function __construct($integer, $byteSize = null, MathAdapterInterface $math = null)
+    {
+        $math = $math ?: EccFactory::getAdapter();
+        $hex = $math->decHex($integer);
+
+        parent::__construct($hex, $byteSize, $math);
+    }
+}

--- a/tests/BufferHexTest.php
+++ b/tests/BufferHexTest.php
@@ -2,7 +2,6 @@
 
 namespace BitWasp\Buffertools\Tests;
 
-
 use BitWasp\Buffertools\BufferHex;
 
 class BufferHexTest extends \PHPUnit_Framework_TestCase

--- a/tests/BufferHexTest.php
+++ b/tests/BufferHexTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace BitWasp\Buffertools\Tests;
+
+
+use BitWasp\Buffertools\BufferHex;
+
+class BufferHexTest extends \PHPUnit_Framework_TestCase
+{
+    public function testHex()
+    {
+        $hex = 'a4e3fd9c';
+        $buffer = new BufferHex($hex);
+        $this->assertEquals($hex, $buffer->getHex());
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testInvalidHex()
+    {
+        new BufferHex('abcdefg');
+    }
+}

--- a/tests/BufferIntTest.php
+++ b/tests/BufferIntTest.php
@@ -2,7 +2,6 @@
 
 namespace BitWasp\Buffertools\Tests;
 
-
 use BitWasp\Buffertools\BufferInt;
 
 class BufferIntTest extends \PHPUnit_Framework_TestCase

--- a/tests/BufferIntTest.php
+++ b/tests/BufferIntTest.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace BitWasp\Buffertools\Tests;
+
+
+use BitWasp\Buffertools\BufferInt;
+
+class BufferIntTest extends \PHPUnit_Framework_TestCase
+{
+    public function testInt()
+    {
+        $int = '12345678901234567890123456789012345678901234567890';
+        $buffer = new BufferInt($int);
+        $this->assertEquals($int, $buffer->getInt());
+    }
+}

--- a/tests/BufferTest.php
+++ b/tests/BufferTest.php
@@ -59,7 +59,7 @@ class BufferTest extends \PHPUnit_Framework_TestCase
     public function testCreateMaxBufferExceeded()
     {
         $lim = 4;
-        $this->buffer = Buffer::hex('414141411', $lim);
+        $this->buffer = Buffer::hex('4141414111', $lim);
     }
 
     public function testCreateHexBuffer()

--- a/tests/Types/ByteStringTest.php
+++ b/tests/Types/ByteStringTest.php
@@ -2,7 +2,6 @@
 
 namespace BitWasp\Buffertools\Tests\Types;
 
-
 use BitWasp\Buffertools\Buffer;
 use BitWasp\Buffertools\Buffertools;
 use BitWasp\Buffertools\ByteOrder;


### PR DESCRIPTION
Adds `BufferHex` and `BufferInt` differing only in the expected type of the first argument. BufferHex will accept hex, and prepare it as a normal Buffer. BufferInt will do the same with positive integers.

The static methods `Buffer::hex()` and `Buffer::int()` are refactored to use these classes, keeping compatibility. 