### PR TITLE
test 7.3 & 7.4, nightly now refers to 8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ php:
   - 7
   - 7.1
   - 7.2
-  - nightly
+  - 7.3
+  - 7.4snapshot
 
 dist: trusty
 


### PR DESCRIPTION
TravisCI has updated their 'nightly' tag to refer to 8.0.0-dev, which causes some packages to break. They haven't added a 7.4 tag for some reason, but do provide `7.4snapshot` for 7.4. This PR removes nightly and adds 7.3 & 7.4snapshot

Prompted by #85 which has test failures