### PR TITLE
[0.5] test 7.3 & 7.4snapshot, nightly now refers to 8.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ php:
   - 7
   - 7.1
   - 7.2
-  - nightly
+  - 7.3
+  - 7.4snapshot
 
 dist: trusty
 


### PR DESCRIPTION
forgot I should have targetted 0.5