### PR TITLE
Fix Buffertools::sort() ternary operation

### DIFF
--- a/src/Buffertools/Buffertools.php
+++ b/src/Buffertools/Buffertools.php
@@ -108,7 +108,7 @@ class Buffertools
         usort($items, function ($a, $b) use ($convertToBuffer) {
             $av = $convertToBuffer($a)->getBinary();
             $bv = $convertToBuffer($b)->getBinary();
-            return $av == $bv ? 0 : $av > $bv ? 1 : -1;
+            return $av == $bv ? 0 : ($av > $bv ? 1 : -1);
         });
 
         return $items;


### PR DESCRIPTION
Ternary operations are, different from other popular languages, left-associative in PHP. Thus the return value of this method was -1 when both values where equal. (Leaving out the parantheses will also become a compile error in PHP 8, https://wiki.php.net/rfc/ternary_associativity.)

```php
$av = 2;
$bv = 2;
$foo = $av == $bv ? 0 : $av > $bv ? 1 : -1;
echo $foo; // -1
```

I found this when scanning for PHP 7.4 deprecations with the [PHPCompatibility tool](https://github.com/PHPCompatibility/PHPCompatibility).