### PR TITLE
Update code style for ternary operator

### DIFF
--- a/src/Buffertools/Buffertools.php
+++ b/src/Buffertools/Buffertools.php
@@ -108,7 +108,7 @@ class Buffertools
         usort($items, function ($a, $b) use ($convertToBuffer) {
             $av = $convertToBuffer($a)->getBinary();
             $bv = $convertToBuffer($b)->getBinary();
-            return $av == $bv ? 0 : $av > $bv ? 1 : -1;
+            return $av == ($bv ? 0 : $av > $bv) ? 1 : -1;
         });
 
         return $items;


### PR DESCRIPTION
Deprecated: Unparenthesized `a ? b : c ? d : e` is deprecated. Use either `(a ? b : c) ? d : e` or `a ? b : (c ? d : e)`