### PR TITLE
backport v0.4: Fix Buffertools::sort() ternary operation

### DIFF
--- a/src/Buffertools/Buffertools.php
+++ b/src/Buffertools/Buffertools.php
@@ -106,7 +106,7 @@ class Buffertools
         usort($items, function ($a, $b) use ($convertToBuffer) {
             $av = $convertToBuffer($a)->getBinary();
             $bv = $convertToBuffer($b)->getBinary();
-            return $av == $bv ? 0 : $av > $bv ? 1 : -1;
+            return $av == $bv ? 0 : ($av > $bv ? 1 : -1);
         });
 
         return $items;


### PR DESCRIPTION
Ternary operations are, different from other popular languages, left-associative in PHP. Thus the return value of this method was -1 when both binaries where equal.